### PR TITLE
Add dark mode (fixes #10)

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>To-Don't</title>
-  <meta name="theme-color" content="#ffffff">
+  <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)">
+  <meta name="theme-color" content="#121212" media="(prefers-color-scheme: dark)">
   <link rel="apple-touch-icon" href="/icon-192.png">
   <link rel="stylesheet" href="styles.css">
 </head>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,17 +61,9 @@ export default function App() {
         <div id="archiveCompletedContainer" style={{ marginBottom: 20, display: 'block' }}>
           <button
             id="archiveCompletedBtn"
+            className="archive-completed-btn"
             disabled={!hasCompletedItems}
-            style={{
-              padding: '6px 12px',
-              fontSize: 13,
-              cursor: hasCompletedItems ? 'pointer' : 'default',
-              border: '1px solid #ddd',
-              background: 'white',
-              borderRadius: 4,
-              color: '#666',
-              opacity: hasCompletedItems ? 1 : 0.4,
-            }}
+            style={{ opacity: hasCompletedItems ? 1 : 0.4 }}
             onClick={actions.archiveCompleted}
           >
             Archive completed

--- a/src/components/TestModePanel.tsx
+++ b/src/components/TestModePanel.tsx
@@ -19,19 +19,21 @@ export function TestModePanel() {
   };
 
   return (
-    <div id="testMode" style={{ display: 'block', position: 'fixed', top: 20, right: 20, fontSize: 13, color: '#999' }}>
+    <div id="testMode" className="test-mode-panel">
       <span id="timeDisplay">Day {timeOffsetDays}</span>
       <button
         id="advanceDay"
+        className="test-mode-btn"
         onClick={advanceDay}
-        style={{ marginLeft: 8, padding: '4px 10px', fontSize: 12, cursor: 'pointer', border: '1px solid #ddd', background: 'white', borderRadius: 4 }}
+        style={{ marginLeft: 8 }}
       >
         +1 day
       </button>
       <button
         id="resetTime"
+        className="test-mode-btn"
         onClick={resetTime}
-        style={{ marginLeft: 4, padding: '4px 10px', fontSize: 12, cursor: 'pointer', border: '1px solid #ddd', background: 'white', borderRadius: 4 }}
+        style={{ marginLeft: 4 }}
       >
         reset
       </button>

--- a/src/hooks/useDragAndDrop.ts
+++ b/src/hooks/useDragAndDrop.ts
@@ -71,7 +71,7 @@ export function useDragAndDrop() {
     cloneContainer.style.top = rect.top + 'px';
     cloneContainer.style.zIndex = '1000';
     cloneContainer.style.pointerEvents = 'none';
-    cloneContainer.style.background = 'white';
+    cloneContainer.style.background = getComputedStyle(document.documentElement).getPropertyValue('--bg-page').trim();
 
     groupElements.forEach(el => {
       const clone = el.cloneNode(true) as HTMLElement;

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,62 @@
+:root {
+  color-scheme: light dark;
+
+  /* Light mode colors (default) */
+  --bg-page: white;
+  --bg-hover: #f0f0f0;
+  --bg-surface: white;
+  --bg-surface-hover: #f5f5f5;
+  --bg-completed-checkbox: #e0e0e0;
+  --bg-tooltip: #f5f5f5;
+  --text-primary: #333;
+  --text-secondary: #666;
+  --text-tertiary: #999;
+  --text-quaternary: #bbb;
+  --text-placeholder: #ccc;
+  --border-light: #eee;
+  --border-default: #ddd;
+  --border-medium: #e0e0e0;
+  --border-strong: #ccc;
+  --border-focus: #999;
+  --color-important-btn: #e53935;
+  --color-important-1: #c62828;
+  --color-important-2: #b71c1c;
+  --color-important-5: #d50000;
+  --color-error: #e53935;
+  --color-link: #1a73e8;
+  --link-underline: rgba(0, 0, 0, 0.3);
+  --shadow-dropdown: rgba(0, 0, 0, 0.12);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg-page: #121212;
+    --bg-hover: #2a2a2a;
+    --bg-surface: #1e1e1e;
+    --bg-surface-hover: #2a2a2a;
+    --bg-completed-checkbox: #3a3a3a;
+    --bg-tooltip: #2a2a2a;
+    --text-primary: #e0e0e0;
+    --text-secondary: #aaa;
+    --text-tertiary: #888;
+    --text-quaternary: #666;
+    --text-placeholder: #555;
+    --border-light: #2a2a2a;
+    --border-default: #333;
+    --border-medium: #333;
+    --border-strong: #444;
+    --border-focus: #666;
+    --color-important-btn: #ef5350;
+    --color-important-1: #ef5350;
+    --color-important-2: #f44336;
+    --color-important-5: #ff1744;
+    --color-error: #ef5350;
+    --color-link: #64b5f6;
+    --link-underline: rgba(255, 255, 255, 0.3);
+    --shadow-dropdown: rgba(0, 0, 0, 0.4);
+  }
+}
+
 * {
   box-sizing: border-box;
   margin: 0;
@@ -7,7 +66,8 @@
 body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   padding: 40px 60px;
-  background: white;
+  background: var(--bg-page);
+  color: var(--text-primary);
   font-size: 16px;
   line-height: 1.6;
 }
@@ -18,7 +78,7 @@ body {
   justify-content: space-between;
   align-items: stretch;
   margin-bottom: 24px;
-  border-bottom: 1px solid #e0e0e0;
+  border-bottom: 1px solid var(--border-medium);
 }
 
 .view-tabs-left {
@@ -30,7 +90,7 @@ body {
   padding: 8px 16px;
   font-size: 14px;
   font-weight: 500;
-  color: #666;
+  color: var(--text-secondary);
   background: none;
   border: none;
   border-bottom: 2px solid transparent;
@@ -40,12 +100,12 @@ body {
 }
 
 .view-tab:hover {
-  color: #333;
+  color: var(--text-primary);
 }
 
 .view-tab.active {
-  color: #333;
-  border-bottom-color: #333;
+  color: var(--text-primary);
+  border-bottom-color: var(--text-primary);
 }
 
 .todo-item {
@@ -62,7 +122,7 @@ body {
   width: 16px;
   margin-top: 4px;
   cursor: grab;
-  color: #ccc;
+  color: var(--text-placeholder);
   opacity: 0;
   transition: opacity 0.15s;
   font-size: 12px;
@@ -77,7 +137,7 @@ body {
   position: fixed;
   pointer-events: none;
   z-index: 1000;
-  background: white;
+  background: var(--bg-page);
 }
 
 .todo-item.drag-clone .drag-handle {
@@ -106,7 +166,7 @@ body {
 .section-header.level-1 .text {
   font-weight: 700;
   font-size: 16px;
-  color: #333;
+  color: var(--text-primary);
   text-transform: uppercase;
   letter-spacing: 0.5px;
   outline: none;
@@ -116,7 +176,7 @@ body {
 .section-header.level-2 .text {
   font-weight: 600;
   font-size: 14px;
-  color: #666;
+  color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.5px;
   outline: none;
@@ -125,7 +185,7 @@ body {
 
 .section-header .text:empty:before {
   content: "Section name...";
-  color: #ccc;
+  color: var(--text-placeholder);
 }
 
 .todo-item.indented {
@@ -150,13 +210,13 @@ body {
   cursor: pointer;
   padding: 2px 6px;
   font-size: 14px;
-  color: #999;
+  color: var(--text-tertiary);
   border-radius: 3px;
 }
 
 .section-header .actions button:hover {
-  background: #f0f0f0;
-  color: #666;
+  background: var(--bg-hover);
+  color: var(--text-secondary);
 }
 
 .section-header .drag-handle {
@@ -165,7 +225,7 @@ body {
   width: 16px;
   margin-top: 2px;
   cursor: grab;
-  color: #ccc;
+  color: var(--text-placeholder);
   opacity: 0;
   transition: opacity 0.15s;
   font-size: 12px;
@@ -179,7 +239,7 @@ body {
 .todo-item .checkbox {
   width: 18px;
   height: 18px;
-  border: 1.5px solid #ccc;
+  border: 1.5px solid var(--border-strong);
   border-radius: 3px;
   margin-right: 10px;
   margin-top: 3px;
@@ -192,18 +252,18 @@ body {
 }
 
 .todo-item:hover .checkbox {
-  border-color: #999;
+  border-color: var(--border-focus);
 }
 
 .todo-item.completed .checkbox {
-  background: #e0e0e0;
-  border-color: #ccc;
-  color: #999;
+  background: var(--bg-completed-checkbox);
+  border-color: var(--border-strong);
+  color: var(--text-tertiary);
 }
 
 .todo-item.completed .text {
   text-decoration: line-through;
-  color: #999;
+  color: var(--text-tertiary);
 }
 
 .todo-item .text {
@@ -215,7 +275,7 @@ body {
 
 .todo-item .date {
   font-size: 13px;
-  color: #bbb;
+  color: var(--text-quaternary);
   margin-left: 12px;
   margin-top: 3px;
   white-space: nowrap;
@@ -239,25 +299,25 @@ body {
   cursor: pointer;
   padding: 2px 6px;
   font-size: 14px;
-  color: #999;
+  color: var(--text-tertiary);
   border-radius: 3px;
 }
 
 .todo-item .actions button:hover {
-  background: #f0f0f0;
-  color: #666;
+  background: var(--bg-hover);
+  color: var(--text-secondary);
 }
 
 .todo-item .actions .important-btn.active {
-  color: #e53935;
+  color: var(--color-important-btn);
 }
 
 /* Important item escalation */
-.todo-item.important-level-1 .text { color: #c62828; }
-.todo-item.important-level-2 .text { color: #b71c1c; font-weight: 600; }
-.todo-item.important-level-3 .text { color: #b71c1c; font-weight: 700; }
-.todo-item.important-level-4 .text { color: #b71c1c; font-weight: 700; text-transform: uppercase; }
-.todo-item.important-level-5 .text { color: #d50000; font-weight: 800; text-transform: uppercase; }
+.todo-item.important-level-1 .text { color: var(--color-important-1); }
+.todo-item.important-level-2 .text { color: var(--color-important-2); font-weight: 600; }
+.todo-item.important-level-3 .text { color: var(--color-important-2); font-weight: 700; }
+.todo-item.important-level-4 .text { color: var(--color-important-2); font-weight: 700; text-transform: uppercase; }
+.todo-item.important-level-5 .text { color: var(--color-important-5); font-weight: 800; text-transform: uppercase; }
 
 .new-item {
   display: flex;
@@ -268,7 +328,7 @@ body {
 .new-item .checkbox {
   width: 18px;
   height: 18px;
-  border: 1.5px dashed #ddd;
+  border: 1.5px dashed var(--border-default);
   border-radius: 3px;
   margin-right: 10px;
   margin-top: 3px;
@@ -282,7 +342,7 @@ body {
 
 .new-item .text:empty:before {
   content: "New item...";
-  color: #ccc;
+  color: var(--text-placeholder);
 }
 
 .new-item .text:focus:empty:before {
@@ -306,7 +366,7 @@ body {
 .day-header {
   font-weight: 600;
   font-size: 14px;
-  color: #666;
+  color: var(--text-secondary);
   padding: 16px 0 8px 0;
   text-transform: uppercase;
   letter-spacing: 0.5px;
@@ -322,13 +382,13 @@ body {
 }
 
 .done-view .todo-item .checkbox {
-  background: #e0e0e0;
-  border-color: #ccc;
-  color: #999;
+  background: var(--bg-completed-checkbox);
+  border-color: var(--border-strong);
+  color: var(--text-tertiary);
 }
 
 .done-view .todo-item .text {
-  color: #666;
+  color: var(--text-secondary);
 }
 
 /* Sync status indicator */
@@ -354,7 +414,7 @@ body {
 
 .sync-label {
   font-size: 12px;
-  color: #bbb;
+  color: var(--text-quaternary);
   opacity: 1;
   transition: color 0.25s, opacity 1s;
 }
@@ -370,9 +430,9 @@ body {
   margin-top: 6px;
   padding: 4px 10px;
   font-size: 11px;
-  color: #666;
-  background: #f5f5f5;
-  border: 1px solid #e0e0e0;
+  color: var(--text-secondary);
+  background: var(--bg-tooltip);
+  border: 1px solid var(--border-medium);
   border-radius: 4px;
   opacity: 0;
   pointer-events: none;
@@ -388,7 +448,7 @@ body {
   color: inherit;
   text-decoration: underline;
   text-underline-offset: 2px;
-  text-decoration-color: rgba(0, 0, 0, 0.3);
+  text-decoration-color: var(--link-underline);
   cursor: pointer;
 }
 
@@ -398,17 +458,17 @@ body {
 
 .todo-item .text[contenteditable="false"] a {
   cursor: pointer;
-  color: #1a73e8;
+  color: var(--color-link);
 }
 
 /* Link editor dialog */
 .link-editor {
   position: fixed;
   z-index: 100;
-  background: white;
-  border: 1px solid #e0e0e0;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-medium);
   border-radius: 6px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+  box-shadow: 0 2px 8px var(--shadow-dropdown);
   padding: 6px 8px;
   display: flex;
   gap: 6px;
@@ -418,19 +478,21 @@ body {
 .link-editor input {
   font-size: 13px;
   padding: 4px 8px;
-  border: 1px solid #ddd;
+  border: 1px solid var(--border-default);
   border-radius: 4px;
   outline: none;
   min-width: 260px;
+  background: var(--bg-surface);
+  color: var(--text-primary);
 }
 
 .link-editor input:focus {
-  border-color: #999;
+  border-color: var(--border-focus);
 }
 
 .link-editor .remove-link {
   font-size: 12px;
-  color: #e53935;
+  color: var(--color-error);
   background: none;
   border: none;
   cursor: pointer;
@@ -453,7 +515,7 @@ body {
   background: none;
   border: none;
   cursor: pointer;
-  color: #999;
+  color: var(--text-tertiary);
   padding: 4px;
   display: flex;
   align-items: center;
@@ -461,8 +523,8 @@ body {
 }
 
 .account-icon-btn:hover {
-  color: #666;
-  background: #f0f0f0;
+  color: var(--text-secondary);
+  background: var(--bg-hover);
 }
 
 .account-dropdown {
@@ -470,10 +532,10 @@ body {
   top: 100%;
   right: 0;
   margin-top: 4px;
-  background: white;
-  border: 1px solid #ddd;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
   border-radius: 6px;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+  box-shadow: 0 2px 8px var(--shadow-dropdown);
   min-width: 180px;
   z-index: 100;
   overflow: hidden;
@@ -482,8 +544,8 @@ body {
 .account-email {
   padding: 10px 14px;
   font-size: 12px;
-  color: #666;
-  border-bottom: 1px solid #eee;
+  color: var(--text-secondary);
+  border-bottom: 1px solid var(--border-light);
   word-break: break-all;
 }
 
@@ -493,14 +555,14 @@ body {
   text-align: left;
   padding: 10px 14px;
   font-size: 13px;
-  color: #333;
+  color: var(--text-primary);
   background: none;
   border: none;
   cursor: pointer;
 }
 
 .account-sign-out:hover {
-  background: #f5f5f5;
+  background: var(--bg-surface-hover);
 }
 
 /* Login form */
@@ -520,7 +582,7 @@ body {
 .login-title {
   font-size: 18px;
   font-weight: 600;
-  color: #333;
+  color: var(--text-primary);
   margin-bottom: 8px;
 }
 
@@ -528,28 +590,30 @@ body {
   font-family: inherit;
   font-size: 14px;
   padding: 8px 12px;
-  border: 1px solid #ddd;
+  border: 1px solid var(--border-default);
   border-radius: 4px;
   outline: none;
+  background: var(--bg-surface);
+  color: var(--text-primary);
 }
 
 .login-input:focus {
-  border-color: #999;
+  border-color: var(--border-focus);
 }
 
 .login-button {
   font-family: inherit;
   font-size: 14px;
   padding: 8px 12px;
-  border: 1px solid #ddd;
+  border: 1px solid var(--border-default);
   border-radius: 4px;
-  background: white;
+  background: var(--bg-surface);
   cursor: pointer;
-  color: #333;
+  color: var(--text-primary);
 }
 
 .login-button:hover {
-  background: #f5f5f5;
+  background: var(--bg-surface-hover);
 }
 
 .login-button:disabled {
@@ -560,7 +624,7 @@ body {
 .login-toggle {
   font-family: inherit;
   font-size: 12px;
-  color: #999;
+  color: var(--text-tertiary);
   background: none;
   border: none;
   cursor: pointer;
@@ -569,10 +633,45 @@ body {
 }
 
 .login-toggle:hover {
-  color: #666;
+  color: var(--text-secondary);
 }
 
 .login-error {
   font-size: 13px;
-  color: #e53935;
+  color: var(--color-error);
+}
+
+/* Archive completed button */
+.archive-completed-btn {
+  padding: 6px 12px;
+  font-size: 13px;
+  border: 1px solid var(--border-default);
+  background: var(--bg-surface);
+  border-radius: 4px;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.archive-completed-btn:disabled {
+  cursor: default;
+}
+
+/* Test mode panel */
+.test-mode-panel {
+  display: block;
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  font-size: 13px;
+  color: var(--text-tertiary);
+}
+
+.test-mode-btn {
+  padding: 4px 10px;
+  font-size: 12px;
+  cursor: pointer;
+  border: 1px solid var(--border-default);
+  background: var(--bg-surface);
+  border-radius: 4px;
+  color: var(--text-primary);
 }

--- a/tests/dark-mode.spec.ts
+++ b/tests/dark-mode.spec.ts
@@ -1,0 +1,125 @@
+import { test, expect } from '@playwright/test';
+import {
+  setupPage,
+  addTodo,
+  getTodoByText,
+  completeTodo,
+  toggleImportant,
+} from './helpers';
+import { createSection } from './helpers';
+
+test.describe('Dark Mode', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupPage(page);
+  });
+
+  test('respects prefers-color-scheme: dark', async ({ page }) => {
+    await page.emulateMedia({ colorScheme: 'dark' });
+    // Wait for styles to apply
+    await page.waitForTimeout(100);
+
+    const bgColor = await page.evaluate(() => {
+      return getComputedStyle(document.body).backgroundColor;
+    });
+    expect(bgColor).toBe('rgb(18, 18, 18)'); // #121212
+  });
+
+  test('uses light mode by default', async ({ page }) => {
+    await page.emulateMedia({ colorScheme: 'light' });
+    await page.waitForTimeout(100);
+
+    const bgColor = await page.evaluate(() => {
+      return getComputedStyle(document.body).backgroundColor;
+    });
+    expect(bgColor).toBe('rgb(255, 255, 255)'); // white
+  });
+
+  test('text is light-colored in dark mode', async ({ page }) => {
+    await addTodo(page, 'Dark mode todo');
+    await page.emulateMedia({ colorScheme: 'dark' });
+    await page.waitForTimeout(100);
+
+    const textColor = await page.locator('.todo-item .text').first().evaluate((el) => {
+      return getComputedStyle(el).color;
+    });
+    // Text should be light (R, G, B all above 180)
+    const match = textColor.match(/rgb\((\d+), (\d+), (\d+)\)/);
+    expect(match).toBeTruthy();
+    const [, r, g, b] = match!.map(Number);
+    expect(r).toBeGreaterThan(180);
+    expect(g).toBeGreaterThan(180);
+    expect(b).toBeGreaterThan(180);
+  });
+
+  test('important items use readable red in dark mode', async ({ page }) => {
+    await addTodo(page, 'Urgent task');
+    await toggleImportant(page, 'Urgent task');
+    await page.emulateMedia({ colorScheme: 'dark' });
+    await page.waitForTimeout(100);
+
+    const todoItem = await getTodoByText(page, 'Urgent task');
+    const textColor = await todoItem.locator('.text').evaluate((el) => {
+      return getComputedStyle(el).color;
+    });
+    // Should be a bright red — R channel high, G and B lower
+    const match = textColor.match(/rgb\((\d+), (\d+), (\d+)\)/);
+    expect(match).toBeTruthy();
+    const [, r, g, b] = match!.map(Number);
+    expect(r).toBeGreaterThan(200); // Bright red
+    expect(g).toBeLessThan(120);
+    expect(b).toBeLessThan(120);
+  });
+
+  test('section headers are readable in dark mode', async ({ page }) => {
+    await createSection(page, 'My Section');
+    await page.emulateMedia({ colorScheme: 'dark' });
+    await page.waitForTimeout(100);
+
+    const sectionColor = await page.locator('.section-header .text').first().evaluate((el) => {
+      return getComputedStyle(el).color;
+    });
+    // Section text should be light enough to read
+    const match = sectionColor.match(/rgb\((\d+), (\d+), (\d+)\)/);
+    expect(match).toBeTruthy();
+    const [, r, g, b] = match!.map(Number);
+    expect(r).toBeGreaterThan(150);
+    expect(g).toBeGreaterThan(150);
+    expect(b).toBeGreaterThan(150);
+  });
+
+  test('view tabs are readable in dark mode', async ({ page }) => {
+    await page.emulateMedia({ colorScheme: 'dark' });
+    await page.waitForTimeout(100);
+
+    const activeTabColor = await page.locator('.view-tab.active').evaluate((el) => {
+      return getComputedStyle(el).color;
+    });
+    // Active tab text should be light
+    const match = activeTabColor.match(/rgb\((\d+), (\d+), (\d+)\)/);
+    expect(match).toBeTruthy();
+    const [, r, g, b] = match!.map(Number);
+    expect(r).toBeGreaterThan(180);
+    expect(g).toBeGreaterThan(180);
+    expect(b).toBeGreaterThan(180);
+  });
+
+  test('completed items are styled correctly in dark mode', async ({ page }) => {
+    await addTodo(page, 'Done task');
+    await completeTodo(page, 'Done task');
+    await page.emulateMedia({ colorScheme: 'dark' });
+    await page.waitForTimeout(100);
+
+    const todoItem = await getTodoByText(page, 'Done task');
+    const textColor = await todoItem.locator('.text').evaluate((el) => {
+      return getComputedStyle(el).color;
+    });
+    // Completed text should still be visible (not black-on-dark)
+    const match = textColor.match(/rgb\((\d+), (\d+), (\d+)\)/);
+    expect(match).toBeTruthy();
+    const [, r, g, b] = match!.map(Number);
+    // Should be at least medium brightness
+    expect(r).toBeGreaterThan(100);
+    expect(g).toBeGreaterThan(100);
+    expect(b).toBeGreaterThan(100);
+  });
+});


### PR DESCRIPTION
## Summary
- Dark mode responsive to system `prefers-color-scheme` setting
- All CSS colors extracted to custom properties with dark overrides
- Background: `#121212` (dark grey), text: `#e0e0e0` (light)
- Important items use brighter reds (`#ef5350`, `#f44336`, `#ff1744`) for dark bg readability
- Inline styles in App.tsx and TestModePanel.tsx extracted to CSS classes
- Dual `theme-color` meta tags for browser chrome

## Test plan
- [ ] Toggle system dark mode and verify the app responds
- [ ] Check text readability, important item colors, section headers
- [ ] Check dropdowns (account menu), tooltips, link editor
- [ ] Verify light mode is unchanged
- 7 new automated tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)