### PR TITLE
Fix: show completed important items in Important view

### DIFF
--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -101,7 +101,7 @@ export function TodoList({
         } else {
           pendingL2 = item;
         }
-      } else if (item.important && !item.completed) {
+      } else if (item.important) {
         if (pendingL1) { importantItems.push(pendingL1); pendingL1 = null; }
         if (pendingL2) { importantItems.push(pendingL2); pendingL2 = null; }
         importantItems.push(item);

--- a/tests/important-view.spec.ts
+++ b/tests/important-view.spec.ts
@@ -64,7 +64,7 @@ test.describe('Important View', () => {
       expect(todoTexts).not.toContain('Normal task');
     });
 
-    test('should not show completed items even if important', async ({ page }) => {
+    test('should show completed items if important', async ({ page }) => {
       // Switch to active view to add items
       await page.locator('#activeViewBtn').click();
 
@@ -76,7 +76,7 @@ test.describe('Important View', () => {
       await page.locator('#importantViewBtn').click();
 
       const todoTexts = await getTodoTexts(page);
-      expect(todoTexts).not.toContain('Important completed');
+      expect(todoTexts).toContain('Important completed');
     });
 
     test('should only show sections that have important items under them', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Completed important items now stay visible in Important view until archived
- Removed `!item.completed` filter from the important view logic in `TodoList.tsx`
- Updated test to expect completed important items to appear (was asserting the opposite)

Fixes #14

## Test plan
- [x] 253 chromium tests pass locally
- [ ] Verify on preview: mark item important, complete it, confirm it stays in Important view
- [ ] Verify archived important items still don't appear