### PR TITLE
Fix immediate visual update when typing ! (fixes #15)

### DIFF
--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -3,6 +3,7 @@ import type { TodoItem as TodoItemType, ViewMode } from '../types';
 import { formatDate, getFadeOpacity, getImportanceLevel, getCursorOffset, splitHTMLAtCursor } from '../utils';
 import { useContentEditable } from '../hooks/useContentEditable';
 import { sanitizeHTML } from '../lib/sanitize';
+import { notifyStateChange } from '../store';
 import { LinkEditor } from './LinkEditor';
 import type { TodoActions } from '../hooks/useTodoActions';
 
@@ -37,6 +38,7 @@ export function TodoItemComponent({ todo, viewMode, now, actions, onKeyDown, onD
 
   const onImportantChange = useCallback((id: string, newImportant: boolean) => {
     window.EventLog.emitFieldChanged(id, 'important', newImportant);
+    notifyStateChange();
   }, []);
 
   const { handleBlur, handleInput, handlePaste, initExclamationCount } = useContentEditable({

--- a/tests/core.spec.ts
+++ b/tests/core.spec.ts
@@ -308,12 +308,14 @@ test.describe('Core Todo Functionality', () => {
     test('should turn on important when typing !', async ({ page }) => {
       await addTodo(page, 'Task');
 
+      const todoItem = page.locator('.todo-item').first();
       const textEl = page.locator('.todo-item .text').first();
       await textEl.click();
       await textEl.press('End');
       await textEl.pressSequentially('!');
 
-      await page.waitForTimeout(100);
+      // Visual class should appear immediately (while still focused)
+      await expect(todoItem).toHaveClass(/important-level-/);
 
       const stored = await getStoredTodos(page);
       expect(stored[0].important).toBe(true);
@@ -323,16 +325,18 @@ test.describe('Core Todo Functionality', () => {
       await addTodo(page, 'Task!');
 
       // Make it important first
-      const todo = page.locator('.todo-item').first();
-      await todo.hover();
-      await todo.locator('.important-btn').click();
+      const todoItem = page.locator('.todo-item').first();
+      await todoItem.hover();
+      await todoItem.locator('.important-btn').click();
+      await expect(todoItem).toHaveClass(/important-level-/);
 
       const textEl = page.locator('.todo-item .text').first();
       await textEl.click();
       await textEl.press('End');
       await textEl.press('Backspace'); // Delete the !
 
-      await page.waitForTimeout(100);
+      // Visual class should be removed immediately (while still focused)
+      await expect(todoItem).not.toHaveClass(/important-level-/);
 
       const stored = await getStoredTodos(page);
       expect(stored[0].important).toBe(false);


### PR DESCRIPTION
## Summary
- The `onImportantChange` callback in TodoItem called `emitFieldChanged` but never called `notifyStateChange()`, so React didn't re-render to apply/remove the `important-level-*` CSS class
- Added the missing `notifyStateChange()` call (consistent with every other mutation in useTodoActions)
- Updated tests to assert the visual class appears/disappears immediately while the field is still focused

## Test plan
- [x] All 253 chromium tests pass
- [ ] Manual test: create item, type `!` at end — item should turn red immediately
- [ ] Manual test: on a red item, delete the `!` — item should lose red immediately

Generated with [Claude Code](https://claude.com/claude-code)