### PR TITLE
Remove dead 'disabled' sync state and fix 'optional sync' language

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ To-Don't is a minimalist todo app where items fade away over 14 days. The core i
 
 ### Data & Sync
 - **localStorage** for immediate persistence
-- **Supabase** for optional cross-device sync
+- **Supabase** for cross-device sync
 - **CRDT-inspired sync** with per-field Last-Write-Wins timestamps
 - **Fractional indexing** for conflict-free ordering
 - Realtime updates via Supabase subscriptions
@@ -60,10 +60,10 @@ Each item tracks per-field timestamps for conflict resolution:
 ## Running the App
 
 ```bash
-# Start Vite dev server (frontend only, sync disabled)
+# Start Vite dev server (frontend only)
 npm run dev
 
-# Start Vite + API server (full stack with sync)
+# Start Vite + API server (full stack)
 npm run dev        # Terminal 1: Vite on :3000
 npm run dev:api    # Terminal 2: Vercel dev on :3001 (proxied via Vite)
 

--- a/PRACTICES.md
+++ b/PRACTICES.md
@@ -4,7 +4,7 @@
 
 - **Frontend**: React 19 with TypeScript, built with Vite
 - **State**: `useSyncExternalStore` over localStorage (event-sourced)
-- **Storage**: Browser localStorage + optional Supabase sync
+- **Storage**: Browser localStorage + Supabase sync
 - **Backend**: Vercel serverless functions (TypeScript)
 - **Database**: Supabase (PostgreSQL) with event sourcing
 - **Testing**: Playwright (end-to-end browser tests)
@@ -92,7 +92,7 @@ Tests run with `?test-mode=1` which enables virtual time manipulation for testin
 
 ### Running Locally
 ```bash
-# Frontend only (sync disabled)
+# Frontend only (no API server)
 npm run dev
 
 # Full stack (two terminals)

--- a/PRODUCT_SPEC.md
+++ b/PRODUCT_SPEC.md
@@ -110,8 +110,8 @@ Note: Sections move with all their children when reordered.
 - Text auto-saves 300ms after typing stops (debounced)
 - Also saves on blur as fallback
 
-### Cross-Device Sync (Optional)
-- Syncs to Supabase when configured
+### Cross-Device Sync
+- Syncs to Supabase
 - CRDT-inspired conflict resolution with per-field timestamps
 - Each field (text, important, completed, position) has its own timestamp
 - Conflicts resolved by Last-Write-Wins on a per-field basis

--- a/src/components/SyncStatus.tsx
+++ b/src/components/SyncStatus.tsx
@@ -10,7 +10,6 @@ const DOT_COLORS: Record<SyncState, string> = {
   error: '#f44336',
   reconnecting: '#9e9e9e',
   offline: '#9e9e9e',
-  disabled: 'transparent',
 };
 
 const LABELS: Record<SyncState, string> = {
@@ -19,7 +18,6 @@ const LABELS: Record<SyncState, string> = {
   error: 'Sync error',
   reconnecting: 'Reconnecting\u2026',
   offline: 'Offline',
-  disabled: '',
 };
 
 export function SyncStatus() {
@@ -43,7 +41,7 @@ export function SyncStatus() {
       }
       setDisplayState('synced');
     } else {
-      // Error, offline, disabled — show immediately
+      // Error, offline — show immediately
       if (syncingTimer.current) {
         clearTimeout(syncingTimer.current);
         syncingTimer.current = null;
@@ -73,8 +71,6 @@ export function SyncStatus() {
       }
     };
   }, [displayState]);
-
-  if (displayState === 'disabled') return null;
 
   const dotColor = DOT_COLORS[displayState];
   const label = LABELS[displayState];

--- a/src/store.ts
+++ b/src/store.ts
@@ -88,7 +88,7 @@ export function useViewMode(): ViewMode {
 }
 
 // Sync status store
-export type SyncState = 'synced' | 'syncing' | 'error' | 'reconnecting' | 'offline' | 'disabled';
+export type SyncState = 'synced' | 'syncing' | 'error' | 'reconnecting' | 'offline';
 
 export interface SyncStatus {
   state: SyncState;


### PR DESCRIPTION
## Summary
- Removed `'disabled'` from `SyncState` type union — no code path ever produced this state
- Removed dead `disabled` handling in `SyncStatus.tsx` (transparent dot, empty label, early return)
- Fixed docs that described sync as "optional" in CLAUDE.md, PRACTICES.md, PRODUCT_SPEC.md

## Test plan
- [ ] TypeScript compiles clean (`npx tsc --noEmit`)
- [ ] Sync status still shows correctly in all states (synced, syncing, error, offline, reconnecting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)