### PR TITLE
Speed up CI with parallel test workers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@v4

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  workers: process.env.CI ? 4 : undefined,
   reporter: 'list',
   use: {
     trace: 'on-first-retry',
@@ -37,6 +37,7 @@ export default defineConfig({
     },
     {
       name: 'sync-e2e-api',
+      fullyParallel: false,
       use: {
         browserName: 'chromium',
         baseURL: `http://localhost:${SYNC_TEST_PORT}`,
@@ -45,6 +46,7 @@ export default defineConfig({
     },
     {
       name: 'sync-e2e',
+      fullyParallel: false,
       use: {
         browserName: 'chromium',
         baseURL: `http://localhost:${SYNC_TEST_PORT}`,


### PR DESCRIPTION
## Summary
- Increase Playwright CI workers from 1 to 4 -- chromium tests are localStorage-only and fully independent
- Set fullyParallel: false on sync-e2e projects so they stay sequential (shared Supabase DB)
- Reduce CI timeout from 30 to 20 minutes

The 249 chromium tests were the bottleneck, running one at a time. With 4 workers they run ~4x faster while sync-e2e tests remain safe.

## Test plan
- [ ] CI passes with parallel workers
- [ ] No flaky test failures from parallelism
- [ ] Total CI time drops significantly (expect ~10 min vs ~20 min)