### PR TITLE
Fix mutable search_path on update_updated_at function

### DIFF
--- a/supabase/migrations/20260218000000_fix_function_search_path.sql
+++ b/supabase/migrations/20260218000000_fix_function_search_path.sql
@@ -1,0 +1,12 @@
+-- Fix mutable search_path on update_updated_at function (fixes #38)
+-- The Supabase linter warns this function has a role-mutable search_path,
+-- which could allow search_path manipulation attacks.
+
+CREATE OR REPLACE FUNCTION update_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql
+SET search_path = '';


### PR DESCRIPTION
## Summary
- Adds Supabase migration to set `search_path = ''` on the `update_updated_at()` trigger function
- Fixes the Supabase linter warning about role-mutable search_path (potential search_path manipulation attack)
- This is on the legacy `items` table trigger — low risk, but worth fixing

Fixes #38

## Test plan
- [ ] Apply migration to remote DB via `supabase db push`
- [ ] Verify Supabase linter no longer shows `function_search_path_mutable` warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)