### PR TITLE
Fix fractional index midpoint generating duplicate/wrong positions

### DIFF
--- a/src/lib/fractional-index.js
+++ b/src/lib/fractional-index.js
@@ -62,15 +62,29 @@ function midpointPosition(before, after) {
     return before.slice(0, diffIndex) + BASE_CHARS[midIdx];
   }
 
+  // Adjacent characters (diff === 1) at diffIndex.
+  // prefix is before's string up to and including the differing char.
+  // Any string starting with prefix is guaranteed < after, so we just
+  // need a suffix that makes the result > before.
   const prefix = before.slice(0, diffIndex + 1);
+
   if (after.length > diffIndex + 1) {
     const restFirstChar = after[diffIndex + 1];
     const restIdx = BASE_CHARS.indexOf(restFirstChar);
     if (restIdx > 1) {
       const midRestIdx = Math.floor(restIdx / 2);
-      return prefix + BASE_CHARS[midRestIdx];
+      const candidate = prefix + BASE_CHARS[midRestIdx];
+      if (candidate > before) {
+        return candidate;
+      }
     }
   }
+
+  // before extends past the diff point — need suffix > before's remaining chars
+  if (before.length > diffIndex + 1) {
+    return prefix + incrementPosition(before.slice(diffIndex + 1));
+  }
+
   return prefix + MID_CHAR;
 }
 


### PR DESCRIPTION
## Summary
- Fix bug in `midpointPosition()` where adjacent characters at the diff point with a longer `before` string would produce positions equal to or less than `before`
- Add regression tests for the specific bug cases and stress tests for consecutive/alternating insertions

## Details

The bug caused new items to appear above their insertion point (sometimes many lines above) when positions got deep enough — typically after ~6 items under a section header. Root cause: `prefix + MID_CHAR` could equal `before` when `before` extended past the diff point.

The fix adds two guards:
1. Check that the after-remaining-chars candidate actually exceeds `before` before returning it
2. When `before` extends past the diff point, use `incrementPosition()` on the remaining suffix instead of just appending `'n'`

Fixes #40

## Test plan
- [x] All 16 previously-buggy input pairs now produce correct results
- [x] Stress test: 30 consecutive insertions between two section positions
- [x] Stress test: 50 alternating insertions produce unique sorted positions  
- [x] All 254 existing chromium tests pass
- [ ] Manual test: create items under a section, verify Enter always inserts on next line

🤖 Generated with [Claude Code](https://claude.com/claude-code)