### PR TITLE
Tab/shift-tab to convert between item and header

### DIFF
--- a/src/components/SectionItem.tsx
+++ b/src/components/SectionItem.tsx
@@ -64,11 +64,15 @@ export function SectionItemComponent({ section, viewMode, actions, onKeyDown, on
     const textEl = textRef.current;
     if (!div || !textEl) return;
 
-    // Tab: demote to level 2
+    // Tab: demote — L1 → L2, L2 → item
     if (e.key === 'Tab' && !e.shiftKey) {
       e.preventDefault();
       actions.updateTodoText(section.id, textEl.innerHTML || '');
-      actions.setSectionLevel(section.id, 2);
+      if ((section.level || 2) === 1) {
+        actions.setSectionLevel(section.id, 2);
+      } else {
+        actions.convertSectionToItem(section.id);
+      }
       return;
     }
 

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -211,10 +211,15 @@ export function TodoItemComponent({ todo, viewMode, now, actions, onKeyDown, onD
       return;
     }
 
-    // Shift-Tab: unindent
+    // Shift-Tab: promote — indented → non-indented, non-indented → L2 section
     if (e.key === 'Tab' && e.shiftKey) {
       e.preventDefault();
-      actions.setTodoIndent(todo.id, false);
+      if (todo.indented) {
+        actions.setTodoIndent(todo.id, false);
+      } else {
+        actions.updateTodoText(todo.id, textEl.innerHTML || '');
+        actions.promoteItemToSection(todo.id);
+      }
       return;
     }
 

--- a/src/hooks/useTodoActions.ts
+++ b/src/hooks/useTodoActions.ts
@@ -308,6 +308,35 @@ export function useTodoActions(pendingFocusRef: React.RefObject<PendingFocus | n
     notifyStateChange();
   }, [pendingFocusRef]);
 
+  const promoteItemToSection = useCallback((id: string) => {
+    const todos = loadTodos();
+    const item = todos.find(t => t.id === id);
+    if (!item || item.type === 'section') return;
+
+    window.EventLog.emitBatch([
+      { type: 'field_changed', itemId: id, field: 'type', value: 'section' },
+      { type: 'field_changed', itemId: id, field: 'level', value: 2 },
+      { type: 'field_changed', itemId: id, field: 'indented', value: false },
+    ]);
+    syncAndEmit();
+    pendingFocusRef.current = { itemId: id };
+    notifyStateChange();
+  }, [pendingFocusRef]);
+
+  const convertSectionToItem = useCallback((id: string) => {
+    const todos = loadTodos();
+    const item = todos.find(t => t.id === id);
+    if (!item || item.type !== 'section') return;
+
+    window.EventLog.emitBatch([
+      { type: 'field_changed', itemId: id, field: 'type', value: 'todo' },
+      { type: 'field_changed', itemId: id, field: 'level', value: null },
+    ]);
+    syncAndEmit();
+    pendingFocusRef.current = { itemId: id };
+    notifyStateChange();
+  }, [pendingFocusRef]);
+
   const setTodoIndent = useCallback((id: string, indented: boolean) => {
     const todos = loadTodos();
     const todo = todos.find(t => t.id === id);
@@ -434,6 +463,8 @@ export function useTodoActions(pendingFocusRef: React.RefObject<PendingFocus | n
     splitLineAt,
     backspaceOnLine,
     convertToSection,
+    promoteItemToSection,
+    convertSectionToItem,
     setTodoIndent,
     setSectionLevel,
     moveItemUp,


### PR DESCRIPTION
## Summary
- Completes the Tab/Shift-Tab hierarchy so all four levels are reachable: **L1 section ↔ L2 section ↔ item ↔ sub-item**
- Tab on an L2 section now converts it to a regular item (previously a no-op)
- Shift-Tab on a non-indented item now converts it to an L2 section header (previously a no-op)
- Text is preserved during all conversions

## Test plan
- [x] New test: L2 section → Tab → regular item with text preserved
- [x] New test: non-indented item → Shift-Tab → L2 section with text preserved
- [x] New test: full cycle through all 4 levels (item → indented → item → L2 section → L1 section → L2 → item) preserving text
- [x] All 20 section tests pass
- [x] All 114 unit tests pass
- [x] All 272 Playwright tests pass (1 pre-existing flaky `link click` test)

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)